### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,15 @@
       {
         "url": "https://app.nutshell.com/api/v1/json",
         "methods": ["POST"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "email": {
+            "header": ["Authorization"]
+          },
+          "api_key": {
+            "header": ["Authorization"]
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This pull request updates the API configuration in `manifest.json` to support injecting authentication settings into request headers, which will help streamline how credentials are managed for API calls.

Authentication settings injection:

* Added a new `settingsInjection` section to the API configuration, enabling both `email` and `api_key` settings to be injected into the `Authorization` header for requests.